### PR TITLE
Fix classmetadata to not add fieldmappings for associations

### DIFF
--- a/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadata.php
@@ -87,10 +87,10 @@ class ClassMetadata implements ClassMetadataInterface
             $mapping['name'] = $mapping['fieldName'];
         }
 
-        $this->fieldMappings[$mapping['fieldName']] = $mapping;
-
         if (isset($mapping['type']) && isset($mapping['targetObject'])) {
             $this->associationMappings[$mapping['fieldName']] = $mapping;
+        } else {
+            $this->fieldMappings[$mapping['fieldName']] = $mapping;
         }
 
         $this->initReflField($mapping);

--- a/tests/Doctrine/SkeletonMapper/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/SkeletonMapper/Tests/Mapping/ClassMetadataTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase;
  */
 class ClassMetadataTest extends PHPUnit_Framework_TestCase
 {
+
     private $class;
 
     protected function setUp()
@@ -128,6 +129,21 @@ class ClassMetadataTest extends PHPUnit_Framework_TestCase
         ));
 
         $this->assertTrue($this->class->hasAssociation('groups'));
+    }
+
+    public function testAddingAssociationMappingDoesNotAddFieldMapping()
+    {
+        $this->assertFalse($this->class->hasAssociation('groups'));
+
+        $this->class->mapField(
+            array(
+                'fieldName' => 'groups',
+                'targetObject' => 'Test',
+                'type' => 'many',
+            )
+        );
+
+        $this->assertFalse($this->class->hasField('groups'));
     }
 
     public function testIsSingleValuedAssociation()


### PR DESCRIPTION
The new behavior maps more closely with existing behavior in other implementations of classmetadata.