### PR TITLE
Use instantiator to create objects without invoking __construct

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^7.1",
         "doctrine/collections": "~1.5",
-        "doctrine/common": "~2.9"
+        "doctrine/common": "~2.9",
+        "doctrine/instantiator": "^1.2"
     },
     "require-dev": {
         "doctrine/coding-standard": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51bb125a3d951658fbcf436767e07a72",
+    "content-hash": "107ff9751d59b6bc2276b85f3b26804a",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -451,6 +451,61 @@
             "time": "2018-06-15T19:03:38+00:00"
         },
         {
+            "name": "doctrine/instantiator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8f58c558d3263405c13df40489c35fe1eefd8f0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8f58c558d3263405c13df40489c35fe1eefd8f0e",
+                "reference": "8f58c558d3263405c13df40489c35fe1eefd8f0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^5.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-shim": "^0.9.2",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2018-09-25T21:32:24+00:00"
+        },
+        {
             "name": "doctrine/lexer",
             "version": "dev-master",
             "source": {
@@ -844,61 +899,6 @@
                 "style"
             ],
             "time": "2018-09-24T19:08:56+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8f58c558d3263405c13df40489c35fe1eefd8f0e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8f58c558d3263405c13df40489c35fe1eefd8f0e",
-                "reference": "8f58c558d3263405c13df40489c35fe1eefd8f0e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-shim": "^0.9.2",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2018-09-25T21:32:24+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/lib/Doctrine/SkeletonMapper/ObjectFactory.php
+++ b/lib/Doctrine/SkeletonMapper/ObjectFactory.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper;
 
-use ReflectionClass;
-use const PHP_VERSION_ID;
-use function sprintf;
-use function strlen;
-use function unserialize;
+use Doctrine\Instantiator\Instantiator;
 
 /**
  * Class for creating object instances without
@@ -16,40 +12,19 @@ use function unserialize;
  */
 class ObjectFactory
 {
-    /** @var object[] */
-    private $prototypes = [];
+    /** @var Instantiator */
+    private $instantiator;
 
-    /** @var ReflectionClass[] */
-    private $reflectionClasses = [];
+    public function __construct()
+    {
+        $this->instantiator = new Instantiator();
+    }
 
     /**
      * @return object
      */
     public function create(string $className)
     {
-        if (! isset($this->prototypes[$className])) {
-            if ($this->isReflectionMethodAvailable()) {
-                $this->prototypes[$className] = $this->getReflectionClass($className)
-                    ->newInstanceWithoutConstructor();
-            } else {
-                $this->prototypes[$className] = unserialize(sprintf('O:%d:"%s":0:{}', strlen($className), $className));
-            }
-        }
-
-        return clone $this->prototypes[$className];
-    }
-
-    protected function isReflectionMethodAvailable() : bool
-    {
-        return PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513 || PHP_VERSION_ID >= 50600;
-    }
-
-    private function getReflectionClass(string $className) : ReflectionClass
-    {
-        if (! isset($this->reflectionClasses[$className])) {
-            $this->reflectionClasses[$className] = new ReflectionClass($className);
-        }
-
-        return $this->reflectionClasses[$className];
+        return $this->instantiator->instantiate($className);
     }
 }


### PR DESCRIPTION
Get rid of `Doctrine\SkeletonMapper\ObjectFactory` and just use `Doctrine\Instantiator\Instantiator` directly.