### PR TITLE
Remove useless chunk of code in doc

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -282,21 +282,6 @@ Create all the necessary services for the mapper:
         $classMetadataFactory
     );
 
-    $userClassMetadata = new ClassMetadata(User::class);
-    $userClassMetadata->setIdentifier(['id']);
-    $userClassMetadata->setIdentifierFieldNames(['id']);
-    $userClassMetadata->mapField([
-        'fieldName' => 'id',
-    ]);
-    $userClassMetadata->mapField([
-        'fieldName' => 'username',
-    ]);
-    $userClassMetadata->mapField([
-        'fieldName' => 'password',
-    ]);
-
-    $classMetadataFactory->setMetadataFor(User::class, $userClassMetadata);
-
     $objectManager = new ObjectManager(
         $objectRepositoryFactory,
         $objectPersisterFactory,


### PR DESCRIPTION
Using `setMetadataFor` seems useless since User class implements `LoadMetadataInterface`.