### PR TITLE
Return iterable instead of array for findAll and findBy methods

### DIFF
--- a/lib/Doctrine/SkeletonMapper/DataRepository/ObjectDataRepositoryInterface.php
+++ b/lib/Doctrine/SkeletonMapper/DataRepository/ObjectDataRepositoryInterface.php
@@ -25,7 +25,7 @@ interface ObjectDataRepositoryInterface
      *
      * @return mixed[][] The objects data.
      */
-    public function findAll() : array;
+    public function findAll() : iterable;
 
     /**
      * Finds objects data by a set of criteria.
@@ -46,7 +46,7 @@ interface ObjectDataRepositoryInterface
         ?array $orderBy = null,
         ?int $limit = null,
         ?int $offset = null
-    ) : array;
+    ) : iterable;
 
     /**
      * Finds a single objects data by a set of criteria.

--- a/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepository.php
+++ b/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepository.php
@@ -87,7 +87,7 @@ abstract class ObjectRepository implements ObjectRepositoryInterface
     *
     * @return object[] The objects.
     */
-    public function findAll() : array
+    public function findAll() : iterable
     {
         $objectsData = $this->objectDataRepository->findAll();
 
@@ -108,7 +108,7 @@ abstract class ObjectRepository implements ObjectRepositoryInterface
     /**
      * {@inheritDoc}
      */
-    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) : array
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) : iterable
     {
         $objectsData = $this->objectDataRepository->findBy(
             $criteria,


### PR DESCRIPTION
What about using iterable type instead of array ? It will allow to return generators or custom result set implementations