### PR TITLE
Address deprecations from persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": "^7.2",
         "doctrine/collections": "~1.5",
         "doctrine/common": "~2.9",
-        "doctrine/instantiator": "^1.1"
+        "doctrine/instantiator": "^1.1",
+        "doctrine/persistence": "^1.3.4"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58d9635a1305bd5cd75746ab07ec63b2",
+    "content-hash": "2608f6038e7f124c7623658e9d594176",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -553,16 +553,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "v1.1.0",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38"
+                "reference": "ff7e08b0f814be2cd20c52dc3c8a262579376b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/ff7e08b0f814be2cd20c52dc3c8a262579376b94",
+                "reference": "ff7e08b0f814be2cd20c52dc3c8a262579376b94",
                 "shasum": ""
             },
             "require": {
@@ -577,19 +577,20 @@
                 "doctrine/common": "<2.10@dev"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "phpstan/phpstan": "^0.8",
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11",
                 "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                    "Doctrine\\Common\\": "lib/Doctrine/Common",
+                    "Doctrine\\Persistence\\": "lib/Doctrine/Persistence"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -598,16 +599,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -631,7 +632,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2018-11-21T00:33:13+00:00"
+            "time": "2020-01-09T19:49:17+00:00"
         },
         {
             "name": "doctrine/reflection",

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -48,7 +48,7 @@ The ``ObjectRepository`` interface is responsible for reading objects:
 
     namespace Doctrine\SkeletonMapper\ObjectRepository;
 
-    use Doctrine\Common\Persistence\ObjectRepository as BaseObjectRepositoryInterface;
+    use Doctrine\Persistence\ObjectRepository as BaseObjectRepositoryInterface;
 
     interface ObjectRepositoryInterface extends BaseObjectRepositoryInterface
     {
@@ -58,7 +58,7 @@ The ``ObjectRepository`` interface is responsible for reading objects:
         public function hydrate($object, array $data);
         public function create($className);
 
-        // inherited from Doctrine\Common\Persistence\ObjectRepository
+        // inherited from Doctrine\Persistence\ObjectRepository
 
         public function find($id);
         public function findAll();

--- a/lib/Doctrine/SkeletonMapper/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/SkeletonMapper/Event/LifecycleEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Event;
 
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
 
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions

--- a/lib/Doctrine/SkeletonMapper/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/SkeletonMapper/Event/OnClearEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Event;
 
-use Doctrine\Common\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
+use Doctrine\Persistence\Event\OnClearEventArgs as BaseOnClearEventArgs;
 
 /**
  * Provides event arguments for the onClear event.

--- a/lib/Doctrine/SkeletonMapper/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/SkeletonMapper/Event/OnFlushEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Event;
 
-use Doctrine\Common\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the onFlush event.

--- a/lib/Doctrine/SkeletonMapper/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/SkeletonMapper/Event/PostFlushEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Event;
 
-use Doctrine\Common\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the postFlush event.

--- a/lib/Doctrine/SkeletonMapper/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/SkeletonMapper/Event/PreFlushEventArgs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Event;
 
-use Doctrine\Common\Persistence\Event\ManagerEventArgs;
+use Doctrine\Persistence\Event\ManagerEventArgs;
 
 /**
  * Provides event arguments for the preFlush event.

--- a/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadataFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Mapping;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory as BaseClassMetadataFactory;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory as BaseClassMetadataFactory;
 
 /**
  * Class responsible for retrieving ClassMetadata instances.

--- a/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadataInterface.php
+++ b/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadataInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\Mapping;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata as BaseClassMetadata;
 
 /**
  * Interface for class metadata instances.

--- a/lib/Doctrine/SkeletonMapper/ObjectManagerInterface.php
+++ b/lib/Doctrine/SkeletonMapper/ObjectManagerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper;
 
-use Doctrine\Common\Persistence\ObjectManager as BaseObjectManagerInterface;
+use Doctrine\Persistence\ObjectManager as BaseObjectManagerInterface;
 use Doctrine\SkeletonMapper\Mapping\ClassMetadataInterface;
 use Doctrine\SkeletonMapper\ObjectRepository\ObjectRepositoryInterface;
 

--- a/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepositoryInterface.php
+++ b/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepositoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\SkeletonMapper\ObjectRepository;
 
-use Doctrine\Common\Persistence\ObjectRepository as BaseObjectRepositoryInterface;
+use Doctrine\Persistence\ObjectRepository as BaseObjectRepositoryInterface;
 
 /**
  * Interface that object repositories must implement.

--- a/tests/Doctrine/SkeletonMapper/Tests/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/SkeletonMapper/Tests/Mapping/ClassMetadataTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\SkeletonMapper\Tests\Mapping;
 
 use BadMethodCallException;
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\SkeletonMapper\Mapping\ClassMetadata;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
A backwards-compatibility layer has been added to persistence to help
consumers move to the new namespacing. It is based on class aliases,
which means the type declaration changes should not be a BC-break: types
are the same.
See doctrine/persistence#71

This means:
- using the new namespaces
- adding autoload calls for new types to types that may be extended and
use persistence types in type declarations of non-constructor methods,
so that signature compatibility is recognized by old versions of php.
Luckily, none of those were found in this repository.
More details on this at
https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf