### PR TITLE
Bump composer dependencies to support newer doctrine package versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,4 +18,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["8.0", "8.1", "8.2"]'
+      php-versions: '["8.0", "8.1", "8.2", "8.3"]'

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/collections": "^1.8",
-        "doctrine/instantiator": "^1.5",
+        "doctrine/collections": "^1.8|^2.2",
+        "doctrine/instantiator": "^1.5|^2.0",
         "doctrine/persistence": "^3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/persistence": "^3.1"
     },
     "require-dev": {
-        "doctrine/coding-standard": "~11.1.0",
+        "doctrine/coding-standard": "^12.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "phpstan/phpstan": "^1.9",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-strict-rules": "^1.4",
-        "phpunit/phpunit": "~9.5"
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
+        "phpstan/phpstan-phpunit": "^1.4",
+        "phpstan/phpstan-strict-rules": "^1.6",
+        "phpunit/phpunit": "~9.6"
     },
     "config": {
         "sort-packages": true,

--- a/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/SkeletonMapper/Mapping/ClassMetadata.php
@@ -100,7 +100,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * The returned structure is an array of the identifier field names.
      *
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getIdentifier(): array
     {
@@ -132,7 +132,7 @@ class ClassMetadata implements ClassMetadataInterface
      *
      * This array includes identifier fields if present on this class.
      *
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getFieldNames(): array
     {
@@ -292,7 +292,7 @@ class ClassMetadata implements ClassMetadataInterface
     /**
      * Returns an array of identifier field names numerically indexed.
      *
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getIdentifierFieldNames(): array
     {

--- a/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepository.php
+++ b/lib/Doctrine/SkeletonMapper/ObjectRepository/ObjectRepository.php
@@ -58,7 +58,7 @@ abstract class ObjectRepository implements ObjectRepositoryInterface
     /**
      * Finds an object by its primary key / identifier.
      *
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @psalm-return T|null
      */


### PR DESCRIPTION
skeleton-mapper is planned to become unmaintained and archived in the future. Ironically there are some steps to be done in other Doctrine packages that would profit from updating Doctrine composer packages in the dependencies of skeleton-mapper itself.

This PR bumps some Doctrine dependencies in composer.json to allow other Doctrine project, that still use the skeleton-mapper, to update their own overlapping dependencies.

I'm not sure if we need to create a 2.1.x branch for these changes though. This isn't a bugfix after all.